### PR TITLE
Adding Support for Switching the Version of Geosupport being Loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,36 @@ except GeosupportError as e:
     print(e.result['List of Street Names']) # List of suggested alternate names
 ```
 
+#### Switching Between Multiple Versions of Geosupport
+
+<span style="color:red">**This feature is Windows only.  Linux doesn't support
+library path modifications during runtime.**</span>
+
+If you have multiple versions of geosupport and want to switch between them,
+you can either pass the installation path to `Geosupport`:
+
+```python
+g = Geosupport(geosupport_path="C:\\Program Files\\Geosupport 18C")
+```
+
+or create a `.python-geosupport.cfg` in your home directory that specifies
+the names and installation paths of the different versions.
+
+The `.python-geosupport.cfg` file looks like:
+
+```txt
+[versions]
+18b=C:\Program Files\Geosupport Desktop Edition
+18c=C:\Program Files\Geosupport 18C
+18c_32=C:\Program Files (x86)\Geosupport 18C
+```
+
+Then you can select the version by name:
+
+```python
+g = Geosupport(geosupport_version="18c")
+```
+
 ## Development
 
 ### Running tests

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ except GeosupportError as e:
 
 #### Switching Between Multiple Versions of Geosupport
 
-<span style="color:red">**This feature is Windows only.  Linux doesn't support
-library path modifications during runtime.**</span>
+:heavy_exclamation_mark: *This feature is Windows only.  Linux doesn't support 
+library path modifications during runtime.*
 
 If you have multiple versions of geosupport and want to switch between them,
 you can either pass the installation path to `Geosupport`:

--- a/geosupport/config.py
+++ b/geosupport/config.py
@@ -17,3 +17,5 @@ BOROUGHS = {
     'STATEN ISLAND': 5, 'SI': 5, 'STATEN IS': 5, 'RICHMOND': 5,
     '': '',
 }
+
+USER_CONFIG = '~/.python-geosupport.cfg'

--- a/geosupport/geosupport.py
+++ b/geosupport/geosupport.py
@@ -1,33 +1,68 @@
 from functools import partial
+import os
 import sys
 
+try:
+    from configparser import ConfigParser # Python 3
+except:
+    from ConfigParser import ConfigParser # Python 2
+
+from .config import USER_CONFIG
 from .error import GeosupportError
 from .function_info import FUNCTIONS, function_help, list_functions, input_help
 from .io import format_input, parse_output, set_mode
 
+GEOLIB = None
+
 class Geosupport(object):
-    def __init__(self):
+    def __init__(self, geosupport_path=None, geosupport_version=None):
+        global GEOLIB
         self.py_version = sys.version_info[0]
         self.platform = sys.platform
         self.py_bit = '64' if (sys.maxsize > 2 ** 32) else '32'
 
+        if geosupport_version is not None:
+            config = ConfigParser()
+            config.read(os.path.expanduser(USER_CONFIG))
+            versions = dict(config['versions'].items())
+            geosupport_path = versions[geosupport_version.lower()]
+
+        if geosupport_path is not None:
+            os.environ['GEOFILES'] = os.path.join(geosupport_path, 'Fls\\')
+            os.environ['PATH'] = ';'.join([
+                i for i in os.environ['PATH'].split(';') if
+                'GEOSUPPORT' not in i.upper()
+            ])
+            os.environ['PATH'] += ';' + os.path.join(geosupport_path, 'bin')
+
         try:
             if self.platform == 'win32':
+                from ctypes import windll, cdll, WinDLL, wintypes
+
+                if GEOLIB is not None:
+                    kernel32 = WinDLL('kernel32')
+                    kernel32.FreeLibrary.argtypes = [wintypes.HMODULE]
+                    kernel32.FreeLibrary(GEOLIB._handle)
+
                 if self.py_bit == '64':
-                    from ctypes import cdll
                     self.geolib = cdll.LoadLibrary("NYCGEO.dll")
                 else:
-                    # must use windll for 32-bit Windows binaries
-                    from ctypes import windll
                     self.geolib = windll.LoadLibrary("NYCGEO.dll")
             elif self.platform.startswith('linux'):
-                import os
                 from ctypes import cdll
+
+                if GEOLIB is not None:
+                    cdll.LoadLibrary('libdl.so').dlclose(GEOLIB._handle)
+
                 self.geolib = cdll.LoadLibrary("libgeo.so")
             else:
-                raise Exception('This Operating System is currently not supported.')
+                raise GeosupportError(
+                    'This Operating System is currently not supported.'
+                )
+
+            GEOLIB = self.geolib
         except OSError as e:
-            sys.exit(
+            raise GeosupportError(
                 '%s\n'
                 'You are currently using a %s-bit Python interpreter. '
                 'Is the installed version of Geosupport %s-bit?' % (

--- a/geosupport/geosupport.py
+++ b/geosupport/geosupport.py
@@ -24,10 +24,16 @@ class Geosupport(object):
         if geosupport_version is not None:
             config = ConfigParser()
             config.read(os.path.expanduser(USER_CONFIG))
-            versions = dict(config['versions'].items())
+            versions = dict(config.items('versions'))
             geosupport_path = versions[geosupport_version.lower()]
 
         if geosupport_path is not None:
+            if self.platform.startswith('linux'):
+                raise GeosupportError(
+                    "geosupport_path and geosupport_version not valid with "
+                    "linux. You must set LD_LIBRARY_PATH and GEOFILES "
+                    "before running python."
+                )
             os.environ['GEOFILES'] = os.path.join(geosupport_path, 'Fls\\')
             os.environ['PATH'] = ';'.join([
                 i for i in os.environ['PATH'].split(';') if


### PR DESCRIPTION
This allows the user to specify which version of Geosupport to use directly from the python API so they don't have to modify environment variables.  

It's Windows only.  It seems to be impossible to do on Linux based on the way that linux loads libraries.  