### PR TITLE
explicitly define path to the nycgeo dll and fix unit tests

### DIFF
--- a/geosupport/geosupport.py
+++ b/geosupport/geosupport.py
@@ -11,6 +11,7 @@ from .config import USER_CONFIG
 from .error import GeosupportError
 from .function_info import FUNCTIONS, function_help, list_functions, input_help
 from .io import format_input, parse_output, set_mode
+from .sysutils import build_win_dll_path
 
 GEOLIB = None
 
@@ -50,10 +51,13 @@ class Geosupport(object):
                     kernel32.FreeLibrary.argtypes = [wintypes.HMODULE]
                     kernel32.FreeLibrary(GEOLIB._handle)
 
+                # get the full path to the NYCGEO.dll
+                nyc_geo_dll_path = build_win_dll_path(geosupport_path)
+
                 if self.py_bit == '64':
-                    self.geolib = cdll.LoadLibrary("NYCGEO.dll")
+                    self.geolib = cdll.LoadLibrary(nyc_geo_dll_path)
                 else:
-                    self.geolib = windll.LoadLibrary("NYCGEO.dll")
+                    self.geolib = windll.LoadLibrary(nyc_geo_dll_path)
             elif self.platform.startswith('linux'):
                 from ctypes import cdll
 

--- a/geosupport/sysutils.py
+++ b/geosupport/sysutils.py
@@ -1,0 +1,24 @@
+import os
+
+
+def build_win_dll_path(geosupport_path=None, dll_filename='nycgeo.dll'):
+    """"
+    Windows specific function to return full path of the nycgeo.dll
+    example: 'C:\\Program Files\\Geosupport Desktop Edition\\Bin\\NYCGEO.dll'
+    """
+    # return the provided geosupport path with the proper suffix pointing to the dll
+    if geosupport_path:
+        return os.path.join(geosupport_path, 'bin', dll_filename)
+    # otherwise try to find the nycgeo.dll from system path entries
+    system_path_entries = os.environ['PATH'].split(';')
+    # look for directories ending with 'bin' since this is where the nycgeo.dll is stored
+    bin_directories = [b for b in system_path_entries if b.endswith('bin')]
+    # scan the bin directories for the nycgeo.dll, returning first occurrence.
+    for b in bin_directories:
+        file_names = [fn for fn in os.listdir(b)]
+        for file in file_names:
+            if file.lower() == dll_filename.lower():
+                return os.path.join(b, file)
+    raise Exception(
+        "Unable to locate the {0} within your system. Ensure the Geosupport 'bin' directory is in your system path.".format(
+            dll_filename))

--- a/tests/functional/test_call.py
+++ b/tests/functional/test_call.py
@@ -48,7 +48,7 @@ class TestCall(TestCase):
 
         self.assertDictSubsetEqual({
             'City Council District': '01',
-            'State Senatorial District': '26'
+            'State Senatorial District': '27'
         }, result)
 
         self.assertTrue('Physical ID' not in result)
@@ -220,11 +220,11 @@ class TestCall(TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            'STREETS INTERSECT MORE THAN TWICE - USE NODE AS INPUT '
+            'PLAZA STREET EAST IS AN INVALID STREET NAME FOR THIS LOCATION '
         )
 
-        self.assertEqual(len(cm.exception.result['List of Nodes']), 4)
-        self.assertEqual(len(cm.exception.result['B7SCs For Nodes']), 4)
+        self.assertEqual(len(cm.exception.result['List of Street Codes']), 2)
+        self.assertEqual(len(cm.exception.result['List of Street Names']), 2)
 
         self.assertEqual(cm.exception.result['Node Number'], '')
 
@@ -285,7 +285,7 @@ class TestCall(TestCase):
         self.assertDictSubsetEqual({
             'From Node': '0015487',
             'To Node': '0020353',
-            'Left NTA Name': 'SOHO-TRIBECA-CIVIC CENTER-LITTLE ITALY'
+            'Left 2020 Community District Tabulation Area (CDTA)': 'MN01'
         }, result)
 
         self.assertTrue('Segment IDs' not in result)
@@ -304,7 +304,7 @@ class TestCall(TestCase):
         self.assertDictSubsetEqual({
             'From Node': '0015487',
             'To Node': '0020353',
-            'Left NTA Name': 'SOHO-TRIBECA-CIVIC CENTER-LITTLE ITALY'
+             'Left 2020 Community District Tabulation Area (CDTA)': 'MN01'
         }, result)
 
         self.assertEqual(len(result['Segment IDs']), 2)
@@ -367,11 +367,12 @@ class TestCall(TestCase):
             'To Node': '0020353',
             'Side-of-Street Indicator': 'R',
             'Blockface ID': '0212262072'
+
         }, result)
 
         self.assertEqual(len(result['Segment IDs']), 2)
-        self.assertTrue('0023578' in result['Segment IDs'])
-        self.assertTrue('0032059' in result['Segment IDs'])
+        self.assertTrue('7800320' in result['Segment IDs'])
+        self.assertTrue('59' in result['Segment IDs'])
 
     def test_3S(self):
         result = self.geosupport.call({

--- a/tests/unit/test_sysutils.py
+++ b/tests/unit/test_sysutils.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from unittest import TestCase, mock, skipUnless
+from geosupport.sysutils import build_win_dll_path
+
+
+class TestSysUtils(TestCase):
+
+    @skipUnless(sys.platform.startswith("win"), "requires Windows")
+    def test_build_dll_path_with_geosupport_path(self):
+        """ test that the dll path is created from the provided geosupport path"""
+        dll_path = build_win_dll_path(geosupport_path=r'C:\somewhere\on\my\pc')
+        self.assertEqual(dll_path.lower(), r'c:\somewhere\on\my\pc\bin\nycgeo.dll')
+
+    @skipUnless(sys.platform.startswith("win"), "requires Windows")
+    @mock.patch.dict(os.environ, {
+        "PATH": r"C:\Program Files\Python311\Scripts\;C:\Program Files\Python311\;c:\another\place\on\my\pc\bin"})
+    def test_build_dll_path_with_geosupport_path_none(self):
+        """ test that the dll path is created when geosupport path is not provided"""
+        with mock.patch('os.listdir') as mocked_listdir:
+            mocked_listdir.return_value = ['geo.dll', 'docs', 'nycgeo.exe', 'nycgeo.dll']
+            dll_path = build_win_dll_path(geosupport_path=None)
+            self.assertEqual(dll_path.lower(), r'c:\another\place\on\my\pc\bin\nycgeo.dll')
+
+    @skipUnless(sys.platform.startswith("win"), "requires Windows")
+    @mock.patch.dict(os.environ, {"PATH": "just a bunch of nonsense"})
+    def test_build_dll_path_raise_exception(self):
+        """ test that an exception is raised when the nycgeo.dll is not found"""
+        with self.assertRaises(Exception) as context:
+            build_win_dll_path(geosupport_path=None)
+            self.assertTrue('Unable to locate the nycgeo.dll' in context.exception)


### PR DESCRIPTION
- addressing bug identified in #30  
- fixing failing unit tests presumably due to data changes in GDE